### PR TITLE
fix: make sure percentage will not show decimals

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,7 +76,7 @@ var BatIndicator = GObject.registerClass(
 
         _getBatteryStatus() { 
    
-            const pct = this.settings.get_boolean("percentage") === true ? this._proxy.Percentage+"%" : "";
+            const pct = this.settings.get_boolean("percentage") === true ? this._proxy.Percentage.toFixed(0)+"%" : "";
 
             //const path = ""
             let batteryType = this.settings.get_int("battery")


### PR DESCRIPTION
Fix one of the issues described [here](https://github.com/wennaspeedy/batt_consumption_wattmetter/issues/4)